### PR TITLE
BugFix: Project wizard always stuck in "no stackfiles panel" 

### DIFF
--- a/src/main/kotlin/com/stackspot/constants/Constants.kt
+++ b/src/main/kotlin/com/stackspot/constants/Constants.kt
@@ -38,10 +38,5 @@ object Constants {
         val USER_HOME: Path = Path(System.getProperty("user.home"))
         val STK_HOME: Path = USER_HOME.resolve(".stk")
         val STK_BIN: Path = STK_HOME.resolve("bin")
-        val STACKS_DIR: Path = if (STK_HOME.resolve("stacks").exists()) {
-            STK_HOME.resolve("stacks")
-        } else {
-            STK_HOME.resolve("plugins")
-        }
     }
 }

--- a/src/main/kotlin/com/stackspot/model/ImportedStacks.kt
+++ b/src/main/kotlin/com/stackspot/model/ImportedStacks.kt
@@ -18,11 +18,13 @@ package com.stackspot.model
 
 import com.stackspot.constants.Constants
 import com.stackspot.yaml.parseStackYaml
+import java.nio.file.Path
+import kotlin.io.path.exists
 
 class ImportedStacks {
 
     fun list(): List<Stack> {
-        val stacksDir = Constants.Paths.STACKS_DIR.toFile()
+        val stacksDir = getStacksDirPath().toFile()
         return stacksDir.walk().filter {
             it.isDirectory
         }.mapNotNull {
@@ -34,5 +36,16 @@ class ImportedStacks {
 
     fun getByName(name: String): Stack? {
         return list().firstOrNull { it.name == name }
+    }
+
+    private fun getStacksDirPath(): Path {
+        val stkHome = Constants.Paths.STK_HOME
+        val stacks = stkHome.resolve("stacks")
+        val stackDir: Path = if (stacks.exists()) {
+            stacks
+        } else {
+            stkHome.resolve("plugins")
+        }
+        return stackDir
     }
 }


### PR DESCRIPTION
… the result from a object was not been updated (it was a constant - JVM URLtic)

Signed-off-by: Matheus Ferreira <matheus.ferreira@zup.com.br>

## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate labits statet is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

When you don't have any stacks imported the project got stuck in the "no imported stackfile" panel. Even when you have imported a stack a few seconds ago.
The error happens because the business logic was in a Kotlin Object. Therefore it was always a constant.

## Solution

To solve this we put the business logic into a private function in the `ImportedStacks` class.

## Results

- Remove the stacks directory in STK_HOME and continue in the project wizard steps
- Imported a stack
- Check if the panel goes to success/default panel