### PR TITLE
Bugfix/stack url dialog

### DIFF
--- a/src/main/kotlin/com/stackspot/intellij/actions/ImportStackAction.kt
+++ b/src/main/kotlin/com/stackspot/intellij/actions/ImportStackAction.kt
@@ -35,7 +35,7 @@ class ImportStackAction : AnAction(IMPORT_STACK, IMPORT_STACK, Icons.IMPORT_STAC
     override fun actionPerformed(e: AnActionEvent) {
         val stackUrl = askForStackUrl() ?: return
 
-        if (stackUrl.isUrlValid()) {
+        if (!stackUrl.isUrlValid()) {
             Messages.showErrorDialog(ErrorDialog.URL_IS_NOT_VALID_MESSAGE, ErrorDialog.URL_IS_NOT_VALID_TITLE)
             return
         }

--- a/src/main/kotlin/com/stackspot/intellij/actions/ImportStackAction.kt
+++ b/src/main/kotlin/com/stackspot/intellij/actions/ImportStackAction.kt
@@ -22,6 +22,9 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.ui.Messages
 import com.stackspot.intellij.commands.listeners.NotifyStacksUpdatedCommandListener
 import com.stackspot.intellij.commands.stk.ImportStack
+import com.stackspot.intellij.commons.ErrorDialog
+import com.stackspot.intellij.commons.InputDialog.REPOSITORY_URL
+import com.stackspot.intellij.commons.isUrlValid
 import com.stackspot.intellij.ui.Icons
 import com.stackspot.intellij.ui.StackSpotTerminalRunner
 
@@ -30,14 +33,20 @@ const val IMPORT_STACK = "Import Stack"
 
 class ImportStackAction : AnAction(IMPORT_STACK, IMPORT_STACK, Icons.IMPORT_STACK), DumbAware {
     override fun actionPerformed(e: AnActionEvent) {
-        val stackUrl = askForStackUrl()
+        val stackUrl = askForStackUrl() ?: return
+
+        if (stackUrl.isUrlValid()) {
+            Messages.showErrorDialog(ErrorDialog.URL_IS_NOT_VALID_MESSAGE, ErrorDialog.URL_IS_NOT_VALID_TITLE)
+            return
+        }
+
         val project = e.project
-        if (stackUrl != null && project != null) {
+        if (project != null) {
             ImportStack(stackUrl, StackSpotTerminalRunner(project)).run(NotifyStacksUpdatedCommandListener())
         }
     }
 
     private fun askForStackUrl(): String? {
-        return Messages.showInputDialog("Enter Stack GIT URL To Import", IMPORT_STACK, Messages.getQuestionIcon())
+        return Messages.showInputDialog(REPOSITORY_URL, IMPORT_STACK, Messages.getQuestionIcon())
     }
 }

--- a/src/main/kotlin/com/stackspot/intellij/commons/UrlDialogExtension.kt
+++ b/src/main/kotlin/com/stackspot/intellij/commons/UrlDialogExtension.kt
@@ -5,7 +5,7 @@ object InputDialog {
 }
 
 object ErrorDialog {
-    const val URL_IS_NOT_VALID_MESSAGE = "Insert a stack repository URL"
+    const val URL_IS_NOT_VALID_MESSAGE = "Requested URL is not valid"
     const val URL_IS_NOT_VALID_TITLE = "Invalid URL"
 }
 

--- a/src/main/kotlin/com/stackspot/intellij/commons/UrlDialogExtension.kt
+++ b/src/main/kotlin/com/stackspot/intellij/commons/UrlDialogExtension.kt
@@ -1,0 +1,15 @@
+package com.stackspot.intellij.commons
+
+object InputDialog {
+    const val REPOSITORY_URL = "Insert a stack repository URL"
+}
+
+object ErrorDialog {
+    const val URL_IS_NOT_VALID_MESSAGE = "Insert a stack repository URL"
+    const val URL_IS_NOT_VALID_TITLE = "Invalid URL"
+}
+
+fun String?.isUrlValid(): Boolean {
+    val regex = """((git|ssh|https)|(git@[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(/)?""".toRegex()
+    return (this?.isNotEmpty() == true) && regex.matches(this)
+}

--- a/src/main/kotlin/com/stackspot/intellij/ui/project_wizard/panels/StackSpotNoStackfilesErrorPanel.kt
+++ b/src/main/kotlin/com/stackspot/intellij/ui/project_wizard/panels/StackSpotNoStackfilesErrorPanel.kt
@@ -67,7 +67,7 @@ class StackSpotNoStackfilesErrorPanel(val parentPanel: StackSpotParentPanel) {
     private fun runImportStack() {
         val url = askForStackUrl() ?: return
 
-        if (url.isUrlValid()) {
+        if (!url.isUrlValid()) {
             Messages.showErrorDialog(URL_IS_NOT_VALID_MESSAGE, URL_IS_NOT_VALID_TITLE)
             return
         }

--- a/src/main/kotlin/com/stackspot/intellij/ui/project_wizard/panels/StackSpotNoStackfilesErrorPanel.kt
+++ b/src/main/kotlin/com/stackspot/intellij/ui/project_wizard/panels/StackSpotNoStackfilesErrorPanel.kt
@@ -24,6 +24,10 @@ import com.stackspot.intellij.actions.IMPORT_STACK
 import com.stackspot.intellij.commands.BackgroundCommandRunner
 import com.stackspot.intellij.commands.listeners.NotifyProjectWizardImportedStack
 import com.stackspot.intellij.commands.stk.ImportStack
+import com.stackspot.intellij.commons.ErrorDialog.URL_IS_NOT_VALID_MESSAGE
+import com.stackspot.intellij.commons.ErrorDialog.URL_IS_NOT_VALID_TITLE
+import com.stackspot.intellij.commons.InputDialog.REPOSITORY_URL
+import com.stackspot.intellij.commons.isUrlValid
 import java.util.concurrent.Executors
 import javax.swing.JComponent
 
@@ -57,18 +61,23 @@ class StackSpotNoStackfilesErrorPanel(val parentPanel: StackSpotParentPanel) {
     }
 
     private fun askForStackUrl(): String? {
-        return Messages.showInputDialog("Enter Stack GIT URL To Import", IMPORT_STACK, Messages.getQuestionIcon())
+        return Messages.showInputDialog(REPOSITORY_URL, IMPORT_STACK, Messages.getQuestionIcon())
     }
 
     private fun runImportStack() {
-        val url = askForStackUrl()
+        val url = askForStackUrl() ?: return
+
+        if (url.isUrlValid()) {
+            Messages.showErrorDialog(URL_IS_NOT_VALID_MESSAGE, URL_IS_NOT_VALID_TITLE)
+            return
+        }
+
         parentPanel.showImportingStack()
+
         val executor = Executors.newSingleThreadExecutor()
         executor.submit {
-            if (!url.isNullOrEmpty()) {
                 ImportStack(url, BackgroundCommandRunner(Constants.Paths.STK_HOME.toString()))
                     .run(NotifyProjectWizardImportedStack(parentPanel))
-            }
         }
         executor.shutdown()
     }


### PR DESCRIPTION
## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

- When you click the "Cancel" button, the stack import screen is displayed

## Solution

- When clicking on the cancel and close button of the dialog box, both from the flow of a new project and from the import from the StackSpot tab, the import screen is no longer displayed;
- Added validation for the URLs.

### Screenshots (if appropriate):

**Flow to create a new project:** 

![new_project](https://user-images.githubusercontent.com/68242531/188150305-1910f022-36f6-480f-978c-00b270bcf208.gif)

**Flow of import via StackSpot tab:**
![import](https://user-images.githubusercontent.com/68242531/188152277-d18ee998-4989-40cb-ae38-a673557c47c8.gif)
