### PR TITLE
fix: added validation if stack file exists inside stack

### DIFF
--- a/src/main/kotlin/com/stackspot/intellij/services/CreateProjectService.kt
+++ b/src/main/kotlin/com/stackspot/intellij/services/CreateProjectService.kt
@@ -37,7 +37,7 @@ class CreateProjectService {
         get() {
             return if (!Constants.Paths.STK_BIN.exists()) {
                 ProjectWizardState.NOT_INSTALLED
-            } else if (ImportedStacks().list().isEmpty()) {
+            } else if (!ImportedStacks().hasStackFiles()) {
                 ProjectWizardState.STACKFILES_EMPTY
             } else if (!isGitConfigOk()) {
                 ProjectWizardState.GIT_CONFIG_NOT_OK

--- a/src/main/kotlin/com/stackspot/intellij/ui/project_wizard/panels/StackSpotNoStackfilesErrorPanel.kt
+++ b/src/main/kotlin/com/stackspot/intellij/ui/project_wizard/panels/StackSpotNoStackfilesErrorPanel.kt
@@ -37,7 +37,7 @@ class StackSpotNoStackfilesErrorPanel(val parentPanel: StackSpotParentPanel) {
         return panel {
             row {
                 text(
-                    "In order to create a StackSpot project, you need to have stacks imported.",
+                    "In order to create a StackSpot project, you need to have stacks imported with <b>stackfiles.</b>",
                     maxLineLength = 80
                 )
             }

--- a/src/main/kotlin/com/stackspot/model/ImportedStacks.kt
+++ b/src/main/kotlin/com/stackspot/model/ImportedStacks.kt
@@ -23,6 +23,8 @@ import kotlin.io.path.exists
 
 class ImportedStacks {
 
+    fun hasStackFiles() = list().any { it.listStackfiles().isNotEmpty() }
+
     fun list(): List<Stack> {
         val stacksDir = getStacksDirPath().toFile()
         return stacksDir.walk().filter {


### PR DESCRIPTION
## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

- When there is no stack in the new project flow, a screen appears with the import stack button. When clicking on the button and importing a stack without "stackfile", the "stackfile" display screen is shown empty.

## Solution

-  Added validation if stackfile exists inside stack and if it does not exist, return to stack import screen
