### PR TITLE
Bug Fix: Changed workflows for plugin publishing

### DIFF
--- a/.github/workflows/check-callback.yml
+++ b/.github/workflows/check-callback.yml
@@ -27,6 +27,7 @@ jobs:
     name: Check Callback
     runs-on: ubuntu-latest
     steps:
+
       - name: Check state - ${{ github.event.client_payload.state }}
         id: check_state
         if: |
@@ -34,6 +35,7 @@ jobs:
         run: |
           echo "Invalid state"
           exit 1
+
       - name: Callback - ${{ github.event.client_payload.state }}
         if: contains(fromJson('["pending", "success", "failure"]'), github.event.client_payload.state)
         run: |
@@ -49,6 +51,7 @@ jobs:
                     "description": "${{ github.event.client_payload.description }}",
                     "target_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }'
+
       - name: Internal error ❌
         if: failure()
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -38,6 +38,9 @@ jobs:
                     "event_type": "RELEASED",
                     "client_payload": {
                       "ref": "${{ github.ref }}",
-                      "statuses_href": "'"$STATUSES_HREF"'"
+                      "statuses_href": "'"$STATUSES_HREF"'",
+                      "release_body": "${{ github.event.release.body }}",
+                      "tag_name": "${{ github.event.release.tag_name }}",
+                      "target_commitish": "${{ github.event.release.target_commitish }}"
                     }
                   }'

--- a/.github/workflows/prereleased.yml
+++ b/.github/workflows/prereleased.yml
@@ -18,7 +18,7 @@ name: Pre released
 
 on:
   repository_dispatch:
-    type: [RELEASE]
+    types: [RELEASE]
 
 jobs:
   check_callback:

--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -42,7 +42,7 @@ jobs:
         id: properties
         run: |
           CHANGELOG="$(cat << 'EOM' | sed -e "/## What's Changed/d" -e 's/^[[:space:]]*$//g' -e '/./,$!d'
-          ${{ github.event.release.body }}
+          ${{ github.event.client_payload.release_body }}
           EOM
           )"
 
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.client_payload.tag_name }}
 
       # Publish the plugin to the Marketplace
       - name: Publish Plugin
@@ -71,7 +71,7 @@ jobs:
           PUBLISH_TOKEN: ${{ secrets.publishToken }}
           MARKETPLACE_CHANNEL: ${{ secrets.marketplaceChannel }}
         run: |
-          TAG=${{ github.event.release.tag_name }}
+          TAG=${{ github.event.client_payload.tag_name }}
           TAG="${TAG//v/""}"
           ./gradlew publishPlugin -Dproject_version=$TAG
 
@@ -80,7 +80,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.accessToken }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
+          gh release upload ${{ github.event.client_payload.tag_name }} ./build/distributions/*
 
   changelog:
     name: Changelog
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.client_payload.tag_name }}
 
       # Update Unreleased section with the current release note
       - name: Patch Changelog
@@ -108,7 +108,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.accessToken }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${{ github.event.client_payload.tag_name }}"
           BRANCH="changelog-update-$VERSION"
           
           git config user.email "action@github.com"
@@ -121,6 +121,6 @@ jobs:
           gh pr create \
             --title "Changelog update - \`$VERSION\`" \
             --body "current pull request contains patched \`changelog.md\` file for the \`$version\` version." \
-            --base "${{ github.event.release.target_commitish }}" \
+            --base "${{ github.event.client_payload.target_commitish }}" \
             --head $BRANCH \
             --label ignore-for-release

--- a/.github/workflows/released.yml
+++ b/.github/workflows/released.yml
@@ -18,7 +18,7 @@ name: Released
 
 on:
   repository_dispatch:
-    type: [RELEASED]
+    types: [RELEASED]
 
 jobs:
   check_callback:
@@ -29,6 +29,7 @@ jobs:
 
   publish:
     name: Publish Plugin
+    if: github.event.client_payload.state == 'success'
     needs:
       - check_callback
     uses: stack-spot/stackspot-intellij-extension/.github/workflows/publish-marketplace.yml@main

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ name: Security
 
 on:
   repository_dispatch:
-    type: [SECURITY]
+    types: [SECURITY]
 
 jobs:
   check_callback:


### PR DESCRIPTION
…nged the plugin's publishing workflow to receive payload variables

Signed-off-by: Adroaldo Neto <adroaldo.neto@zup.com.br>

## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

- Callback workflows are triggered simultaneously and plugin publishing workflow does not get the value of variables

## Solution

- Added the letter s in the type of callback workflows and changed the plugin's publishing workflow to receive payload variables
