### PR TITLE
Bug Fix: Moved changelog jobs into deploy prod workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,7 +21,72 @@ on:
     types: [released]
 
 jobs:
-  DISPATCH_EVENT:
+  export_properties:
+    name: Export Properties
+    runs-on: ubuntu-latest
+    outputs:
+      changelog: ${{ steps.properties.outputs.changelog }}
+    steps:
+      # Set environment variables
+      - name: Export Properties
+        id: properties
+        run: |
+          CHANGELOG="$(cat << 'EOM' | sed -e "/## What's Changed/d" -e 's/^[[:space:]]*$//g' -e '/./,$!d'
+          ${{ github.event.release.body }}
+          EOM
+          )"
+
+          CHANGELOG="${CHANGELOG//'%'/'%25'}"
+          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+          CHANGELOG="${CHANGELOG//'**Full Changelog**'/'Full Changelog'}"
+
+          echo "::set-output name=changelog::$CHANGELOG"
+
+  changelog:
+    name: Changelog
+    needs:
+      - export_properties
+    runs-on: ubuntu-latest
+    steps:
+      # Check out current repository
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      # Update Unreleased section with the current release note
+      - name: Patch Changelog
+        if: ${{ needs.export_properties.outputs.changelog != '' }}
+        env:
+          CHANGELOG: ${{ needs.export_properties.outputs.changelog }}
+        run: |
+          ./gradlew patchChangelog --release-note="$CHANGELOG"
+
+      # Create pull request
+      - name: Create Pull Request
+        if: ${{ needs.export_properties.outputs.changelog != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.accessToken }}
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          BRANCH="changelog-update-$VERSION"
+
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+
+          git checkout -b $BRANCH
+          git commit -asm "Changelog update - $VERSION"
+          git push --set-upstream origin $BRANCH
+
+          gh pr create \
+            --title "Changelog update - \`$VERSION\`" \
+            --body "current pull request contains patched \`changelog.md\` file for the \`$version\` version." \
+            --base "${{ github.event.release.target_commitish }}" \
+            --head $BRANCH \
+            --label ignore-for-release
+
+  dispatch_event:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch init event
@@ -39,8 +104,6 @@ jobs:
                     "client_payload": {
                       "ref": "${{ github.ref }}",
                       "statuses_href": "'"$STATUSES_HREF"'",
-                      "release_body": "${{ github.event.release.body }}",
-                      "tag_name": "${{ github.event.release.tag_name }}",
-                      "target_commitish": "${{ github.event.release.target_commitish }}"
+                      "tag_name": "${{ github.event.release.tag_name }}"
                     }
                   }'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,11 +21,10 @@ on:
     types: [released]
 
 jobs:
-  export_properties:
-    name: Export Properties
+
+  changelog:
+    name: Changelog
     runs-on: ubuntu-latest
-    outputs:
-      changelog: ${{ steps.properties.outputs.changelog }}
     steps:
       # Set environment variables
       - name: Export Properties
@@ -43,12 +42,6 @@ jobs:
 
           echo "::set-output name=changelog::$CHANGELOG"
 
-  changelog:
-    name: Changelog
-    needs:
-      - export_properties
-    runs-on: ubuntu-latest
-    steps:
       # Check out current repository
       - name: Checkout
         uses: actions/checkout@v3
@@ -57,15 +50,15 @@ jobs:
 
       # Update Unreleased section with the current release note
       - name: Patch Changelog
-        if: ${{ needs.export_properties.outputs.changelog != '' }}
+        if: ${{ steps.properties.outputs.changelog != '' }}
         env:
-          CHANGELOG: ${{ needs.export_properties.outputs.changelog }}
+          CHANGELOG: ${{ steps.properties.outputs.changelog }}
         run: |
           ./gradlew patchChangelog --release-note="$CHANGELOG"
 
       # Create pull request
       - name: Create Pull Request
-        if: ${{ needs.export_properties.outputs.changelog != '' }}
+        if: ${{ steps.properties.outputs.changelog != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.accessToken }}
         run: |

--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -31,27 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  export_properties:
-    name: Export Properties
-    runs-on: ubuntu-latest
-    outputs:
-      changelog: ${{ steps.properties.outputs.changelog }}
-    steps:
-      # Set environment variables
-      - name: Export Properties
-        id: properties
-        run: |
-          CHANGELOG="$(cat << 'EOM' | sed -e "/## What's Changed/d" -e 's/^[[:space:]]*$//g' -e '/./,$!d'
-          ${{ github.event.client_payload.release_body }}
-          EOM
-          )"
 
-          CHANGELOG="${CHANGELOG//'%'/'%25'}"
-          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
-          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
-          CHANGELOG="${CHANGELOG//'**Full Changelog**'/'Full Changelog'}"
-
-          echo "::set-output name=changelog::$CHANGELOG"
 
   # Prepare and publish the plugin to the Marketplace repository
   publish:
@@ -81,46 +61,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.accessToken }}
         run: |
           gh release upload ${{ github.event.client_payload.tag_name }} ./build/distributions/*
-
-  changelog:
-    name: Changelog
-    needs:
-      - export_properties
-    runs-on: ubuntu-latest
-    steps:
-      # Check out current repository
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.client_payload.tag_name }}
-
-      # Update Unreleased section with the current release note
-      - name: Patch Changelog
-        if: ${{ needs.EXPORT_PROPERTIES.outputs.changelog != '' }}
-        env:
-          CHANGELOG: ${{ needs.EXPORT_PROPERTIES.outputs.changelog }}
-        run: |
-          ./gradlew patchChangelog --release-note="$CHANGELOG"
-
-      # Create pull request
-      - name: Create Pull Request
-        if: ${{ needs.EXPORT_PROPERTIES.outputs.changelog != '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.accessToken }}
-        run: |
-          VERSION="${{ github.event.client_payload.tag_name }}"
-          BRANCH="changelog-update-$VERSION"
-          
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-          
-          git checkout -b $BRANCH
-          git commit -asm "Changelog update - $VERSION"
-          git push --set-upstream origin $BRANCH
-          
-          gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
-            --body "current pull request contains patched \`changelog.md\` file for the \`$version\` version." \
-            --base "${{ github.event.client_payload.target_commitish }}" \
-            --head $BRANCH \
-            --label ignore-for-release


### PR DESCRIPTION
Signed-off-by: Adroaldo Neto <adroaldo.neto@zup.com.br>

## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

- Event triggering for production deployment has broken payload due to changelog body

## Solution

- Moved changelog jobs into deploy prod workflow