### PR TITLE
Bug Fix: Changed changelog extension in build gradle and disable buildSearchableOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 ## Releases
 
-## [v0.1.4] - 2022-09-16
-CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 
 ## Releases
 
+## [v0.1.4] - 2022-09-16
+CHANGELOG
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,11 +35,11 @@ changelog {
     val regex =
         Regex("""^v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)${'$'}""")
     headerParserRegex.set(regex)
-    header.set(provider { "[v${version.get()}] - ${date()}" })
+    header.set(provider { "[v${project.version}] - ${date()}" })
 
     unreleasedTerm.set("Releases")
     itemPrefix.set("*")
-    version.set(version)
+    version.set(project.version as String)
 
     groups.set(emptyList())
 }
@@ -57,6 +57,10 @@ tasks {
     patchPluginXml {
         sinceBuild.set("221")
         untilBuild.set("222.*")
+    }
+
+    buildSearchableOptions {
+        enabled = false
     }
 
     publishPlugin {


### PR DESCRIPTION
…e buildSearchableOptions

Signed-off-by: Adroaldo Neto <adroaldo.neto@zup.com.br>

## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

- When trying to publish plug-ins, it shows an error in the workflow

## Solution

- Changed changelog extension in build gradle and disable buildSearchableOptions