### PR TITLE
Bug Fix: Add mock for git config command runner

### DIFF
--- a/src/test/kotlin/com/stackspot/intellij/services/CreateProjectServiceTest.kt
+++ b/src/test/kotlin/com/stackspot/intellij/services/CreateProjectServiceTest.kt
@@ -48,6 +48,7 @@ internal class CreateProjectServiceTest {
 
     @Nested
     inner class FailureCases {
+
         @Test
         fun `service state should be STACKFILES_EMPTY`() {
             every { importedStacks.hasStackFiles() } returns false
@@ -95,6 +96,7 @@ internal class CreateProjectServiceTest {
 
     @Nested
     inner class SuccessCases {
+
         @Test
         fun `should clear service attributes`() {
             val service = CreateProjectService().saveInfo(createStack(), createStackfile())
@@ -109,9 +111,11 @@ internal class CreateProjectServiceTest {
         @Test
         fun `service state should be OK`() {
             every { importedStacks.hasStackFiles() } returns true
-            val service = CreateProjectService(importedStacks, isInstalled = true)
+            every { (gitConfigCmd.runner as BackgroundCommandRunner).stdout } returns "ok"
+            val service = CreateProjectService(importedStacks, isInstalled = true, gitConfigCmd = gitConfigCmd)
             service.state shouldBe ProjectWizardState.OK
             verify { importedStacks.hasStackFiles() }
+            verify(exactly = 2) { gitConfigCmd.run() }
             confirmVerified(importedStacks)
         }
 


### PR DESCRIPTION
## Checklist Reviewer

- [ ] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [ ] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [ ] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [ ] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [ ] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [ ] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

When running in CI pipelines (GHA) one test was not being executed. The problem is that it was trying to run the git command instead of being mocked.

## Solution

To solve this we mock the git command.
