### PR TITLE
Bug Fix: Remove template requirement validation

### DIFF
--- a/src/main/kotlin/com/stackspot/intellij/services/StackSpotToolWindowService.kt
+++ b/src/main/kotlin/com/stackspot/intellij/services/StackSpotToolWindowService.kt
@@ -60,8 +60,12 @@ class StackSpotToolWindowService {
     }
 
     fun pluginsOrTemplatesNotApplied(plugins: List<String>? = null): List<String> {
+        /**
+         * Link to check: https://app.shortcut.com/stackspot/story/392379/ide-intellij-bug-valida%C3%A7%C3%A3o-requirement-em-apply-plugin-com-app-sem-template
+         */
+
         return plugins
-            ?.filter { p -> appliedPlugins.none { ap -> ap.templateDataPath == p } && p != template?.templateDataPath }
+            ?.filter { p -> appliedPlugins.none { ap -> ap.templateDataPath == p } }
             ?.toList() ?: listOf()
     }
 }


### PR DESCRIPTION
Check this link: https://app.shortcut.com/stackspot/story/392379/ide-intellij-bug-valida%C3%A7%C3%A3o-requirement-em-apply-plugin-com-app-sem-template

Signed-off-by: Matheus Ferreira <matheus.ferreira@zup.com.br>

## Checklist Reviewer

- [ ] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [ ] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [ ] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [ ] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [ ] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [ ] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

For a specific scenario when a user creates an app without a template, the requirements validation of plugins should fail and it was possible to apply the plugin.

[Shortcut story link](https://app.shortcut.com/stackspot/story/392379/ide-intellij-bug-valida%C3%A7%C3%A3o-requirement-em-apply-plugin-com-app-sem-template)

## Solution

Template requirements were removed until the STK CLI team will solve the history file (stk.yaml).
A comment and a link were added to better understanding this issue.
