### PR TITLE
fix: returning the template requirements check

### DIFF
--- a/src/main/kotlin/com/stackspot/intellij/services/StackSpotToolWindowService.kt
+++ b/src/main/kotlin/com/stackspot/intellij/services/StackSpotToolWindowService.kt
@@ -60,12 +60,8 @@ class StackSpotToolWindowService {
     }
 
     fun pluginsOrTemplatesNotApplied(plugins: List<String>? = null): List<String> {
-        /**
-         * Link to check: https://app.shortcut.com/stackspot/story/392379/ide-intellij-bug-valida%C3%A7%C3%A3o-requirement-em-apply-plugin-com-app-sem-template
-         */
-
         return plugins
-            ?.filter { p -> appliedPlugins.none { ap -> ap.templateDataPath == p } }
+            ?.filter { p -> appliedPlugins.none { ap -> ap.templateDataPath == p } && p != template?.templateDataPath }
             ?.toList() ?: listOf()
     }
 }


### PR DESCRIPTION
It was mistakenly removed. When a app is created by stackfile all plugins in the stackfile are applied. That's is why the dependency are resolved and the other plugin are enabled to apply

Signed-off-by: Matheus Ferreira <matheus.ferreira@zup.com.br>

## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

It was mistakenly removed. When an app is created by stackfile all plugins in the stackfile are applied. That is why the dependency is resolved and the other plugin is enabled to apply.

Undo https://github.com/stack-spot/stackspot-intellij-extension/pull/64

## Solution

Return the template requirement validation.