### PR TITLE
Bug Fix: Added condition missing operators

### DIFF
--- a/src/main/kotlin/com/stackspot/model/Condition.kt
+++ b/src/main/kotlin/com/stackspot/model/Condition.kt
@@ -17,7 +17,6 @@
 package com.stackspot.model
 
 import com.intellij.openapi.ui.naturalSorted
-
 data class Condition(val variable: String, val operator: String, var value: Any) {
 
     companion object {
@@ -30,7 +29,9 @@ data class Condition(val variable: String, val operator: String, var value: Any)
             "<=" to ::lte,
             "containsAny" to ::containsAny,
             "containsAll" to ::containsAll,
-            "containsOnly" to ::containsOnly
+            "containsOnly" to ::containsOnly,
+            "notContainsAny" to ::notContainsAny,
+            "notContainsAll" to ::notContainsAll
         )
 
         private fun eq(variableValue: Any, value: Any): Boolean =
@@ -67,12 +68,33 @@ data class Condition(val variable: String, val operator: String, var value: Any)
             }
         }
 
+        private fun notContainsAny(variableValue: Any, value: Any): Boolean {
+            return when {
+                variableValue is String && value is ArrayList<*> -> value.none { v ->
+                    (variableValue.toMutableSet()).contains(v)
+                }
+
+                variableValue is String && value is String -> !variableValue.contains(value)
+                variableValue is Set<*> && value is String -> !variableValue.contains(value)
+                else -> (value as ArrayList<*>).none { v -> (variableValue as Set<*>).contains(v) }
+            }
+        }
+
         private fun containsAll(variableValue: Any, value: Any): Boolean {
             return when {
                 variableValue is String && value is ArrayList<*> -> variableValue.toMutableSet().containsAll(value)
                 variableValue is String && value is String -> variableValue == value
                 variableValue is Set<*> && value is String -> variableValue.containsAll(value.toMutableSet())
-                else -> (variableValue as Set<*> ).containsAll(value as ArrayList<*>)
+                else -> (variableValue as Set<*>).containsAll(value as ArrayList<*>)
+            }
+        }
+
+        private fun notContainsAll(variableValue: Any, value: Any): Boolean {
+            return when {
+                variableValue is String && value is ArrayList<*> -> !variableValue.toMutableSet().containsAll(value)
+                variableValue is String && value is String -> variableValue != value
+                variableValue is Set<*> && value is String -> !variableValue.containsAll(value.toMutableSet())
+                else -> !(variableValue as Set<*>).containsAll(value as ArrayList<*>)
             }
         }
 

--- a/src/main/kotlin/com/stackspot/model/Input.kt
+++ b/src/main/kotlin/com/stackspot/model/Input.kt
@@ -26,7 +26,7 @@ data class Input(
     val default: Any?,
     val condition: Condition?,
     val required: Boolean = false,
-    val items: Set<String>? = null,
+    val items: List<String>? = null,
     val pattern: String? = null,
     val help: String? = null
 ) {


### PR DESCRIPTION
## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

- It is not possible to use the notContainsAll and notContainsAny condition operators on inputs, both do not work.

## Solution

- Added the rules for the notContainsAll and notContainsAny condition operators