### PR TITLE
Bug Fix: Decreased the response time to select the Stackfile of the new project

### DIFF
--- a/src/main/kotlin/com/stackspot/intellij/services/CreateProjectService.kt
+++ b/src/main/kotlin/com/stackspot/intellij/services/CreateProjectService.kt
@@ -24,19 +24,27 @@ import com.stackspot.intellij.services.enums.ProjectWizardState
 import com.stackspot.model.ImportedStacks
 import com.stackspot.model.Stack
 import com.stackspot.model.Stackfile
+import com.stackspot.model.StkVersion
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-private const val STK_VERSION_MESSAGE = "stk version"
-
 @Service
 class CreateProjectService() {
+
+    init {
+        runBlocking {
+            launch { ImportedStacks.getInstance() }
+            launch { StkVersion.getInstance() }
+        }
+    }
 
     var stack: Stack? = null
     var stackfile: Stackfile? = null
     val state: ProjectWizardState
         get() {
-            return if (!isInstalled()) {
+            return if (!StkVersion.getInstance().isInstalled()) {
                 ProjectWizardState.NOT_INSTALLED
             } else if (!ImportedStacks.getInstance().hasStackFiles()) {
                 ProjectWizardState.STACKFILES_EMPTY
@@ -56,11 +64,6 @@ class CreateProjectService() {
     ) : this() {
         this.version = version
         this.gitConfigCmd = gitConfigCmd
-    }
-
-    private fun isInstalled(): Boolean {
-        val stdout = version.runSync().stdout
-        return stdout.contains(STK_VERSION_MESSAGE)
     }
 
     fun isStackfileSelected(): Boolean = stack != null && stackfile != null

--- a/src/main/kotlin/com/stackspot/jackson/JacksonExtensions.kt
+++ b/src/main/kotlin/com/stackspot/jackson/JacksonExtensions.kt
@@ -76,8 +76,9 @@ inline fun <reified T> String.parseJsonToMapWithList(): HashMap<String, List<T>>
     return JacksonExtensions.objectMapperJson.readValue(content, typeRef)
 }
 
+const val SQUARE_BRACKETS = "[]"
 inline fun <reified T> String.parseJsonToList(): List<T> {
-    val content = if (this.contains(CURLY_BRACKETS)) "[]" else this
+    val content = if (this.contains(SQUARE_BRACKETS)) SQUARE_BRACKETS else this
     val typeRef: TypeReference<List<T>> = object : TypeReference<List<T>>() {}
     return JacksonExtensions.objectMapperJson.readValue(content, typeRef)
 }

--- a/src/main/kotlin/com/stackspot/model/StkVersion.kt
+++ b/src/main/kotlin/com/stackspot/model/StkVersion.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stackspot.model
+
+import com.stackspot.intellij.commands.stk.Version
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+private const val STK_VERSION_MESSAGE = "stk version"
+
+class StkVersion(private val version: Version) {
+
+    private lateinit var stkVersion: String
+
+    init {
+        runBlocking {
+            launch { stkVersion = version.runAsync().await().stdout }
+        }
+    }
+
+    companion object {
+        @Volatile
+        private lateinit var instance: StkVersion
+
+        fun getInstance(
+            version: Version = Version(),
+            newInstance: Boolean = false
+        ): StkVersion {
+            synchronized(this) {
+                if (!::instance.isInitialized || newInstance) {
+                    instance = StkVersion(version)
+                }
+                return instance
+            }
+        }
+    }
+
+    fun isInstalled(): Boolean {
+        return stkVersion.contains(STK_VERSION_MESSAGE)
+    }
+}

--- a/src/test/kotlin/com/stackspot/intellij/services/CreateProjectServiceTest.kt
+++ b/src/test/kotlin/com/stackspot/intellij/services/CreateProjectServiceTest.kt
@@ -70,18 +70,24 @@ internal class CreateProjectServiceTest {
         @Test
         fun `service state should be STACKFILES_EMPTY`() {
             every { ImportedStacks.getInstance(any(), any(), any(), any()).hasStackFiles() } returns false
-            every { version.runSync().stdout } returns "stk version"
+            coEvery { version.runAsync().await().stdout } returns "stk version"
+            StkVersion.getInstance(version)
+            every { StkVersion.getInstance(any()).isInstalled() } returns true
+
             val service = CreateProjectService(version = version)
+
             service.state shouldBe ProjectWizardState.STACKFILES_EMPTY
             verify { ImportedStacks.getInstance(any(), any(), any(), any()).hasStackFiles() }
+            verify { StkVersion.getInstance(any()).isInstalled() }
             confirmVerified(ImportedStacks)
+            confirmVerified(StkVersion)
         }
 
         @Test
         fun `service state should be NOT_INSTALLED`() {
             coEvery { version.runAsync().await().stdout } returns ""
             StkVersion.getInstance(version)
-            coEvery { StkVersion.getInstance(any()).isInstalled() } returns false
+            every { StkVersion.getInstance(any()).isInstalled() } returns false
 
             val service = CreateProjectService(version = version)
 
@@ -93,9 +99,13 @@ internal class CreateProjectServiceTest {
         @Test
         fun `service state should be GIT_CONFIG_NOT_OK`() {
             every { ImportedStacks.getInstance(any(), any(), any(), any()).hasStackFiles() } returns true
-            every { version.runSync().stdout } returns "stk version"
+            coEvery { version.runAsync().await().stdout } returns "stk version"
+            StkVersion.getInstance(version)
+            every { StkVersion.getInstance(any()).isInstalled() } returns true
             every { (gitConfigCmd.runner as BackgroundCommandRunner).stdout } returns ""
+
             val service = CreateProjectService(gitConfigCmd = gitConfigCmd, version = version)
+
             service.state shouldBe ProjectWizardState.GIT_CONFIG_NOT_OK
             verify { ImportedStacks.getInstance(any(), any(), any(), any()).hasStackFiles() }
             verify { gitConfigCmd.run() }
@@ -109,6 +119,10 @@ internal class CreateProjectServiceTest {
             stackfile: Stackfile?,
             expected: Boolean
         ) {
+            coEvery { version.runAsync().await().stdout } returns "stk version"
+            StkVersion.getInstance(version)
+            every { StkVersion.getInstance(any()).isInstalled() } returns true
+
             val service = CreateProjectService().saveInfo(stack, stackfile)
             Assertions.assertEquals(service.isStackfileSelected(), expected)
         }
@@ -138,9 +152,13 @@ internal class CreateProjectServiceTest {
         @Test
         fun `service state should be OK`() {
             every { ImportedStacks.getInstance(any(), any(), any(), any()).hasStackFiles() } returns true
-            every { version.runSync().stdout } returns "stk version"
+            coEvery { version.runAsync().await().stdout } returns "stk version"
+            StkVersion.getInstance(version)
+            every { StkVersion.getInstance(any()).isInstalled() } returns true
             every { (gitConfigCmd.runner as BackgroundCommandRunner).stdout } returns "ok"
+
             val service = CreateProjectService(gitConfigCmd = gitConfigCmd, version = version)
+
             service.state shouldBe ProjectWizardState.OK
             verify { ImportedStacks.getInstance(any(), any(), any(), any()).hasStackFiles() }
             verify(exactly = 2) { gitConfigCmd.run() }
@@ -161,6 +179,10 @@ internal class CreateProjectServiceTest {
         @ParameterizedTest
         @MethodSource("saveInfoArgs")
         fun `should saveInfo when args aren't null`(stack: Stack?, stackfile: Stackfile?) {
+            coEvery { version.runAsync().await().stdout } returns "stk version"
+            StkVersion.getInstance(version)
+            every { StkVersion.getInstance(any()).isInstalled() } returns true
+
             val service = CreateProjectService().saveInfo(stack, stackfile)
             service.asClue {
                 it.stack shouldBe stack
@@ -171,6 +193,7 @@ internal class CreateProjectServiceTest {
         @ParameterizedTest
         @MethodSource("saveInfoNullArgs")
         fun `should saveInfo when args are null`(stack: Stack?, stackfile: Stackfile?) {
+
             val service = CreateProjectService().saveInfo(stack, stackfile)
             service.asClue {
                 it.stack shouldBe stack
@@ -185,6 +208,10 @@ internal class CreateProjectServiceTest {
             stackfile: Stackfile?,
             expected: Boolean
         ) {
+            coEvery { version.runAsync().await().stdout } returns "stk version"
+            StkVersion.getInstance(version)
+            every { StkVersion.getInstance(any()).isInstalled() } returns true
+
             val service = CreateProjectService().saveInfo(stack, stackfile)
             Assertions.assertEquals(service.isStackfileSelected(), expected)
         }

--- a/src/test/kotlin/com/stackspot/model/ImportedStacksTest.kt
+++ b/src/test/kotlin/com/stackspot/model/ImportedStacksTest.kt
@@ -104,8 +104,14 @@ class ImportedStacksTest {
                     - stk cli successfully initialized!
                     {}
                 """
+        val stackStdout = """
+                    > Initializing stk cli...
+                    - stacks folder created!
+                    - stk cli successfully initialized!
+                    []
+                """
 
-        coEvery { stackInfoList.runAsync().await().stdout } returns stdout
+        coEvery { stackInfoList.runAsync().await().stdout } returns stackStdout
         coEvery { stackfileInfoList.runAsync().await().stdout } returns stdout
         coEvery { templateInfoList.runAsync().await().stdout } returns stdout
         coEvery { pluginInfoList.runAsync().await().stdout } returns stdout


### PR DESCRIPTION
## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

- When clicking on a new project and later on the Stackpot option (which loads the Stackfiles), it takes a while to respond, giving the impression that it is locked

## Solution

- Created structure for a single instance of the command to get the version and added execution with coroutines
