### PR TITLE
Bug Fix: Command apply plugin in right working directory

### DIFF
--- a/src/main/kotlin/com/stackspot/intellij/ui/StackSpotTerminalRunner.kt
+++ b/src/main/kotlin/com/stackspot/intellij/ui/StackSpotTerminalRunner.kt
@@ -102,7 +102,7 @@ class StackSpotTerminalRunner(private val project: Project) : CommandRunner {
         window.show()
         val contentManager = window.contentManager
         val stackSpotTab = contentManager.contents.firstOrNull { Constants.MODULE_TYPE_NAME == it.tabName }
-        val resolvedWorkingDir = workingDir ?: project.basePath
+        val resolvedWorkingDir = project.basePath ?: workingDir
         val terminalView = TerminalView.getInstance(project)
         if (stackSpotTab != null) {
             terminalView.closeTab(stackSpotTab)


### PR DESCRIPTION
The default value of workingdir is STK_HOME

Signed-off-by: Matheus Ferreira <matheus.ferreira@zup.com.br>

## Checklist Reviewer

- [x] Check if the _pull request_ references the link (url) of the _ISSUE_ or _TASK_ related to the implementation.

- [x] Make sure the _pull request_ has a clear description of what was implemented, with gifs (using [terminalizer](https://terminalizer.com/)) if possible.

- [x] Check if the _pull request_ has an appropriate label for the state it is in (`WIP`, `ready-for-review`, `bug`, etc...).

- [x] Check if the _pull request_ needs a walkthrough for _reviewers_ to test the implementation.

- [x] Check if the code present in the _pull request_ has been tested (unit and integrated tests) if necessary.

- [x] Check that the _pull request_ was opened against the correct branch (`main` for `fix`, `release-x.y.x` for new features or improvements).

* * *

## Issue Description

Commands were being executed in STK_HOME instead of the project base path.

## Solution

Use the project base path as default, if not exists (or null) use the workingDir variable. The default value of workingDir is STK_HOME.
